### PR TITLE
Make TransferMap compatible with API V2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start:dev": "nodemon app.js"
   },
   "dependencies": {
-    "@wetransfer/js-sdk": "0.5.0",
+    "@wetransfer/js-sdk": "1.0.0",
     "dotenv": "6.0.0",
     "express": "4.16.3",
     "express-fileupload": "0.4.0",

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -1,26 +1,109 @@
 (function() {
   const transfersForm = document.getElementById('transfer-create');
+  const formSubmit = document.getElementById('submit');
 
   if (!transfersForm) {
     return;
   }
 
-  transfersForm.addEventListener('submit', (event) => {
-    // stop our form submission from refreshing the page
+  function createTransfer(event) {
+    // Stop our form submission from refreshing the page
     event.preventDefault();
 
-    const data = new FormData();
-    data.append('file', event.target.elements.files.files[0]);
-    data.append('radius', event.target.elements.radius.value);
-    data.append('latitude', event.target.elements.latitude.value);
-    data.append('longitude', event.target.elements.longitude.value);
+    formSubmit.disabled = true;
+    formSubmit.value = 'Uploading...';
+
+    const files = Array.from(event.target.elements.files.files).map((file) => ({
+      name: file.name,
+      size: file.size,
+    }));
+
+    const radius = event.target.elements.radius.value;
+    const latitude = event.target.elements.latitude.value;
+    const longitude = event.target.elements.longitude.value;
 
     fetch('/transfers/create', {
       method: 'POST',
-      body: data
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        files,
+        latitude,
+        longitude
+      })
     })
       .then((response) => response.json())
+      .then((transfer) => uploadFiles(transfer, event.target.elements.files.files))
+      .then((transfer) => finalizeTransfer(transfer.id, radius, latitude, longitude))
       .then((success) => window.location.assign(`/transfers/${success.linkHash}`))
       .catch((error) => console.log(error));
-  });
+  }
+
+  async function uploadFiles(transfer, files) {
+    console.info('Uploading files...');
+    const fileUploads = transfer.files.map(async (file, index) => {
+      console.info(`Uploading file with name ${file.name} and size ${file.size}B`);
+      for (
+        let partNumber = 0;
+        partNumber < file.multipart.part_numbers;
+        partNumber++
+      ) {
+        const chunkStart = partNumber * file.multipart.chunk_size;
+        const chunkEnd = (partNumber + 1) * file.multipart.chunk_size;
+
+        console.info(`Requesting upload URL for part #${partNumber+1} of ${file.multipart.part_numbers}`);
+        const { url } = await fetch(
+          `/transfers/${transfer.id}/files/${file.id}/upload-url/${partNumber+1}`, {
+            headers: {
+              'Content-Type': 'application/json',
+            }
+          }).then((response) => response.json());
+
+        console.info(`Uploading chunk from ${chunkStart} to ${chunkEnd}`);
+        await fetch(url, {
+          method: 'PUT',
+          body: files[index].slice(chunkStart, chunkEnd),
+        });
+      }
+
+      // Complete file upload
+      console.info(`${file.name} upload complete`);
+      return await fetch(
+        `/transfers/upload-complete`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            transfer,
+            file
+          })
+        }).then((response) => response.json());
+    });
+
+    // Wait until all files have been uploaded
+    await Promise.all(fileUploads);
+
+    return transfer;
+  }
+
+  async function finalizeTransfer(transferId, radius, latitude, longitude) {
+    // Finalize transfer
+    console.info('Finalize transfer!');
+    return await fetch(
+      `/transfers/${transferId}/finalize`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          latitude,
+          longitude,
+          radius
+        })
+      }).then((response) => response.json());
+  }
+
+  transfersForm.addEventListener('submit', createTransfer);
 })();

--- a/services/sqlite.js
+++ b/services/sqlite.js
@@ -54,7 +54,7 @@ async function init(filePath) {
 
 function insertTransfer(transfer) {
   const stmt = db.prepare(query.INSERT_TRANSFER);
-  const link = transfer.shortened_url;
+  const link = transfer.url;
   const linkHash = crypto.createHash('md5').update(link).digest('hex');
   stmt.run(linkHash, link, transfer.latitude, transfer.longitude, transfer.radius);
   stmt.finalize();

--- a/services/wetransfer.js
+++ b/services/wetransfer.js
@@ -1,30 +1,63 @@
 const https = require('https');
 const createWTClient = require('@wetransfer/js-sdk');
 
-async function createTransfer(name, description, files) {
-  const wtClient = await createWTClient(process.env.wt_api_key);
+async function createTransfer(message, files) {
+  const wtClient = await createWTClient(process.env.wt_api_key, {
+    logger: {
+      level: 'silly',
+    },
+  });
 
   const transfer = await wtClient.transfer.create({
-    name,
-    description
+    message,
+    files
   });
 
-  const transferFileItems = await wtClient.transfer.addFiles(
-    transfer,
-    files.map((file, index) => ({
-      filename: file.name,
-      filesize: file.data.length
-    }))
+  return transfer;
+}
+
+async function getUploadUrl(transferId, fileId, partNumber) {
+  const wtClient = await createWTClient(process.env.wt_api_key, {
+    logger: {
+      level: 'silly',
+    },
+  });
+
+  return await wtClient.transfer.getFileUploadURL(
+    transferId,
+    fileId,
+    partNumber
   );
+}
 
-  transferFileItems.forEach((item, index) => {
-    // Don't hit the API limit for public keys
-    setTimeout(() => wtClient.transfer.uploadFile(item, files[index].data), index * 200);
+async function completeFileUpload(transfer, file) {
+  const wtClient = await createWTClient(process.env.wt_api_key, {
+    logger: {
+      level: 'silly',
+    },
   });
 
-  return transfer.shortened_url;
+  return await wtClient.transfer.completeFileUpload(
+    transfer,
+    file
+  );
+}
+
+async function finalizeTransfer(transferId) {
+  const wtClient = await createWTClient(process.env.wt_api_key, {
+    logger: {
+      level: 'silly',
+    },
+  });
+
+  return await wtClient.transfer.finalize(
+    { id: transferId }
+  );
 }
 
 module.exports = {
-  createTransfer
+  createTransfer,
+  getUploadUrl,
+  completeFileUpload,
+  finalizeTransfer
 };

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -11,7 +11,7 @@
     </div>
     <div class="files">
       <h2>Pick your files</h2>
-      <input type="file" id="files" name="file" required>
+      <input type="file" id="files" name="files" multiple required>
     </div>
     <span class="submit">
       <input type="hidden" id="latitude" name="latitude">


### PR DESCRIPTION
Because we release the new version of our API. The biggest difference compared with the previous version is that now the files are uploaded directly from the browser to S3, instead of uploading the files through the server.